### PR TITLE
I1BCIP-65 create email password auth

### DIFF
--- a/common/serializer.py
+++ b/common/serializer.py
@@ -22,7 +22,7 @@ from common.models import (
 )
 
 class RegisterUserSerializer(serializers.Serializer):
-    email = serializers.EmailField(validators=[EmailValidator()])
+    email = serializers.EmailField()
     password = serializers.CharField(write_only=True)
 
     def validate_password(self, value):

--- a/common/urls.py
+++ b/common/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
         name="token_refresh",
     ),
     # GoogleLoginView
+    path('auth/register/', views.RegisterUserView.as_view(), name='register'),
     path("auth/login/", views.LoginView.as_view()),
     path("auth/google/", views.GoogleLoginView.as_view()),
     path('auth-config/', views.AuthConfigView.as_view()),

--- a/common/views.py
+++ b/common/views.py
@@ -82,6 +82,31 @@ from django.contrib.auth.models import Group
 logger = logging.getLogger(__name__)
 
 
+class RegisterUserView(APIView):
+    authentication_classes = []
+
+    @extend_schema(
+        request=RegisterUserSerializer,
+        tags=["auth"],
+        responses={
+            200: "User registered successfully",
+            400: "Bad Request",
+            500: "Internal Server Error",
+        },
+    )
+    def post(self, request, *args, **kwargs):
+        if User.objects.exists():
+            return Response({'error': True, 'errors': 'No new users can be created. Please contact the admin to send you an invitation to create a new account.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        serializer = RegisterUserSerializer(data=request.data)
+        
+        if serializer.is_valid():
+            serializer.save()
+            return Response({'error': False, 'message': 'User registered successfully.'}, status=status.HTTP_201_CREATED)
+        
+        return Response({'error': True, 'errors': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+        
+
 class SendForgotPasswordEmail(APIView):
     authentication_classes = []
 

--- a/common/views.py
+++ b/common/views.py
@@ -101,8 +101,19 @@ class RegisterUserView(APIView):
         serializer = RegisterUserSerializer(data=request.data)
         
         if serializer.is_valid():
-            serializer.save()
-            return Response({'error': False, 'message': 'User registered successfully.'}, status=status.HTTP_201_CREATED)
+            user = serializer.save()
+            
+            refresh = RefreshToken.for_user(user)
+            access_token = str(refresh.access_token)
+
+            return Response({
+                'error': False, 
+                'message': 'User registered successfully.',
+                'username': user.email,
+                'access_token': access_token,
+                'refresh_token': str(refresh),
+                'user_id': user.id
+            }, status=status.HTTP_201_CREATED)
         
         return Response({'error': True, 'errors': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
         

--- a/common/views.py
+++ b/common/views.py
@@ -1246,7 +1246,10 @@ class AuthConfigView(APIView):
             return Response({"error": True, "message": "AuthConfig not found for this organization."}, status=status.HTTP_404_NOT_FOUND)
 
         serializer = AuthConfigSerializer(auth_config)
-        return Response({"error": False, "data": serializer.data}, status=status.HTTP_200_OK)
+        is_first_user = not User.objects.exists()
+        
+        return Response({"error": False, "data": {"is_google_login": serializer.data["is_google_login"],  "is_first_user": is_first_user}}, 
+                         status=status.HTTP_200_OK)
 
     @extend_schema(
         tags=["auth"],


### PR DESCRIPTION
### Overview

This branch implements backend logic to control user registration, ensuring that only the first user can register directly through the application. Any subsequent user must be invited by the first registered administrator to create an account. This feature is crucial for maintaining control over who can access the system by limiting unauthorized registrations.

**NOTE**: You can test this functionality directly via API requests using Swagger Or using frontend: [I1BCIP-65-create-email-password-auth](https://github.com/gaidds/React-crm-project/pull/18).

---

### API Endpoint

#### Register a New User
- **Path:** `/auth/register/`
- **Method:** `POST`
- **Description:** This endpoint allows a user to register only if no other users exist in the database. If a user already exists, registration will be blocked, and an error message will be returned.

**Expected Input:**
```json
{
  "email": "user@example.com",
  "password": "yourpassword"
}
```

**Expected Response:**
- **Success:** `201 Created` with a message indicating successful user registration.
  ```json
  {
    "error": false,
    "message": "User registered successfully."
  }
  ```
- **Failure:** `400 Bad Request` with error details if:
  - The database already contains a user.
  - The email or password is missing or invalid.
  ```json
  {
    "error": true,
    "errors": "No new users can be created. Please contact the admin to send you an invitation to create a new account."
  }
  ```

### Expected Test Results

1. **Empty Database:**
   - **Outcome:** Registering the first user with a valid email and password should succeed.
   - **Response:** `201 Created` with a success message, and the user should be saved in the database.

2. **Non-Empty Database:**
   - **Outcome:** Any attempt to register a new user should fail.
   - **Response:** `400 Bad Request` with an error message indicating that no new users can be created.

3. **Validation Errors:**
   - **Outcome:** Omitting the email or password in the request should result in a failure.
   - **Response:** `400 Bad Request` with appropriate error messages detailing the missing or invalid fields.

---

### How to Test

1. **API Testing via Swagger:**
   - Use Swagger or a similar API testing tool to send POST requests to the `/auth/register/` endpoint.
   - **Steps Using Swagger:**
     1. Navigate to `http://localhost:8000/swagger-ui/`.
     2. Under the "auth" group, use the `/api/auth/register/` endpoint.
     3. Add new user information in the following format:
        ```json
        {
          "email": "firstuser@example.com",
          "password": "yourpassword"
        }
        ```

2. **Frontend Testing:**
   - The frontend branch is  [I1BCIP-65-create-email-password-auth](https://github.com/gaidds/React-crm-project/pull/18).

---