### PR TITLE
Modify users/profile serializers

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -226,6 +226,8 @@ class Profile(BaseModel):
     @property
     def user_details(self):
         return {
+            'first_name': self.user.first_name,
+            'last_name' : self.user.last_name,
             'email': self.user.email,
             'id':  self.user.id,
             'is_active': self.user.is_active,

--- a/common/utils.py
+++ b/common/utils.py
@@ -70,8 +70,6 @@ ROLES = (
     ("SALES MANAGER", "SALES MANAGER"),
     ("SALES REP", "SALES REP"),
     ("USER", "USER"),
-    ("SALES REP", "SALES REP"),
-    ("SALES MANAGER", "SALES MANAGER"),
 )
 
 


### PR DESCRIPTION
In this branch I just fixed the `user_details` so in the frontend we can access users first and last name.
I also noticed the roles are repeated so I removed the redundant tuples.

This branch should be merged to I1BCIP25. 

This will be needed for users page, profile page, and the modals.