### PR TITLE
I1BCIP-66 fix org

### DIFF
--- a/common/serializer.py
+++ b/common/serializer.py
@@ -119,7 +119,7 @@ class OrgProfileCreateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Org
-        fields = ["name"]
+        fields = ["name", "id"]
         extra_kwargs = {
             "name": {"required": True}
         }

--- a/common/serializer.py
+++ b/common/serializer.py
@@ -127,7 +127,7 @@ class OrgProfileCreateSerializer(serializers.ModelSerializer):
     def validate_name(self, name):
         if bool(re.search(r"[~\!_.@#\$%\^&\*\ \(\)\+{}\":;'/\[\]]", name)):
             raise serializers.ValidationError(
-                "organization name should not contain any special characters"
+                "Organization name should not contain any special characters"
             )
         if Org.objects.filter(name=name).exists():
             raise serializers.ValidationError(
@@ -135,6 +135,12 @@ class OrgProfileCreateSerializer(serializers.ModelSerializer):
             )
         return name
 
+    def validate(self, data):
+        if Org.objects.exists():
+            raise serializers.ValidationError(
+                "An organization already exists. Only one organization is allowed."
+            )
+        return data
 
 class ShowOrganizationListSerializer(serializers.ModelSerializer):
     """


### PR DESCRIPTION
## 1. **Change Summary**

- **Validation Added**: The system now restricts the creation of multiple organizations. Only one organization can exist in the database at any time.
- **Response Update**: The response of the organization includes the `id`, making it easier to identify the organization.

## 3. **How to Test via Swagger**

### 1. **Testing Organization Creation**

- **Endpoint**: `POST /org`
- **Request Body**:
  ```json
  {
    "name": "New Organization"
  }
  ```
- **Success Response** (First organization created):
  ```json
  {
    "error": False,
    "message": "New Org is Created.",
    "org": {
      "name": "New Organization",
      "id": 1
    },
    "org_id": 1,
    "status": 201
  }
  ```
- **Error Response** (If an organization already exists):
  ```json
  {
    "non_field_errors": [
      "An organization already exists. Only one organization is allowed."
    ]
  }
  ```