### PR TITLE
I1BCIP32-Fix-Bug-Created/Updated_by

### DIFF
--- a/common/base.py
+++ b/common/base.py
@@ -23,7 +23,9 @@ class BaseModel(AuditModel):
         # Extract the user from the token or session
         user = get_current_user()
         uid = kwargs.pop('uidb64', None)
-        
+        if uid is None and user.is_anonymous:
+            if self.uidb64:
+                uid = self.uidb64
         # If the user is updating their info through the link
         if uid:
             try:

--- a/common/base.py
+++ b/common/base.py
@@ -9,6 +9,7 @@ from crum import get_current_user
 # Module imports
 from common.mixins import AuditModel
 
+from django.contrib.auth import get_user_model
 
 class BaseModel(AuditModel):
     id = models.UUIDField(
@@ -19,20 +20,33 @@ class BaseModel(AuditModel):
         abstract = True
 
     def save(self, *args, **kwargs):
+        # Extract the user from the token or session
         user = get_current_user()
+        uid = kwargs.pop('uidb64', None)
+        
+        # If the user is updating their info through the link
+        if uid:
+            try:
+                # Get the user object using the UID
+                user = get_user_model().objects.get(pk=uid)
+            except get_user_model().DoesNotExist:
+                user = None
+
         if user is None or user.is_anonymous:
             self.created_by = None
             self.updated_by = None
-            super(BaseModel, self).save(*args, **kwargs)
         else:
-            # Check if the model is being created or updated
+            # If the record is being created for the first time
             if self._state.adding:
-                # If created only set created_by value: set updated_by to None
-                self.created_by = user
+                if not self.created_by:
+                    # Set created_by only if it is not already set
+                    self.created_by = user
                 self.updated_by = None
-            # If updated only set updated_by value don't touch created_by
-            self.updated_by = user
-            super(BaseModel, self).save(*args, **kwargs)
+            else:
+                # If the record is being updated, set updated_by without modifying created_by
+                self.updated_by = user
+                
+        super(BaseModel, self).save(*args, **kwargs)
 
     def __str__(self):
         return str(self.id)

--- a/common/views.py
+++ b/common/views.py
@@ -259,14 +259,14 @@ class PasswordResetConfirmAPIView(APIView):
                         address_serializer = BillingAddressSerializer(
                             profile.address, data=address_data, partial=True)
                         if address_serializer.is_valid():
-                            address_serializer.save()
+                            address_serializer.save(uidb64=uid)
                         else:
                             return Response({'errors': address_serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
                     else:  # If no existing address, create a new one
                         address_serializer = BillingAddressSerializer(
                             data=address_data)
                         if address_serializer.is_valid():
-                            profile.address = address_serializer.save()
+                            profile.address = address_serializer.save(uidb64=uid)
                         else:
                             return Response({'errors': address_serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -277,7 +277,7 @@ class PasswordResetConfirmAPIView(APIView):
                     form.save()
 
                     # Save the profile updates
-                    profile.save()
+                    profile.save(uidb64=uid)
 
                     return Response({'message': 'Password and profile information have been set successfully'}, status=status.HTTP_200_OK)
                 else:


### PR DESCRIPTION
The bug was about the **creatd_by** and **updated_by** ids in the database table when the user sets their address and password after receiving the invitation email from admin.
The columns would be set to null due to the fact that user is still not authorised when setting their password and filling their information up for the first time.
By modifying the save method, now only if the user is setting their password for the first time then the save method can retrieve the data of this user object without authorisation and set the `updated_by_id` and `created_by_id` columns in the database accordingly.

## Test guide:

- Invite a user and after receiving the email try to set their password and address for the first time.
- Check the database tables `address` and `profile` and see if the `update_by_id` and `created_by_id` are set correctly.
- `updated_by_id` should be the id of the newly invited user and `created_by_id` should be the id of the admin who invited this user.